### PR TITLE
Add notify for ble device to support binding

### DIFF
--- a/platinum-bluetooth-device.html
+++ b/platinum-bluetooth-device.html
@@ -160,6 +160,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
          */
         device: {
           type: BluetoothDevice,
+          notify: true,
           readOnly: true,
           observer: '_deviceChanged'
         }


### PR DESCRIPTION
This PR adds `notify:true` to the `<platinum-bluetooth-device>.device` to support binding via `<platinum-bluetooth-device device={{device}}>` and listening to changes to the device via `on-device-changed` on the `<platinum-bluetooth-device>` element. If needed a test case that fails with the current  element can be added.